### PR TITLE
Feature/update cosmosdb course query

### DIFF
--- a/CoursesApiHttpTrigger/course_fetcher.py
+++ b/CoursesApiHttpTrigger/course_fetcher.py
@@ -28,9 +28,9 @@ class CourseFetcher:
         # Create an SQL query to retrieve the course document
         query = (
             "SELECT * from c "
-            f"where c.course.institution.pub_ukprn = '{institution_id}' "
-            f"and c.course.kis_course_id = '{course_id}' "
-            f"and c.course.mode.code = '{mode}' "
+            f"where c.institution_id = '{institution_id}' "
+            f"and c.course_id = '{course_id}' "
+            f"and c.course_mode = '{mode}' "
             f"and c.version = '{version}' ")
 
         logging.info(f'query: {query}')
@@ -66,7 +66,7 @@ class CourseFetcher:
     def tidy_course(course):
         """Removes the key/value pairs Cosmos DB adds to the course"""
 
-        keys_to_delete = ['_rid', '_self', '_etag', '_attachments', '_ts']
+        keys_to_delete = ['_rid', '_self', '_etag', '_attachments', '_ts', 'institution_id', 'course_id', 'course_mode']
         for key in keys_to_delete:
             try:
                 del course[key]

--- a/CoursesApiHttpTrigger/tests/test_tidy_course.py
+++ b/CoursesApiHttpTrigger/tests/test_tidy_course.py
@@ -1,0 +1,75 @@
+import unittest
+import os
+import sys
+import inspect
+
+CURRENTDIR = os.path.dirname(
+    os.path.abspath(inspect.getfile(inspect.currentframe())))
+PARENTDIR = os.path.dirname(CURRENTDIR)
+sys.path.insert(0, PARENTDIR)
+
+from course_fetcher import CourseFetcher
+
+class TestTidyCourse(unittest.TestCase):
+    def test_rid_is_deleted(self):
+        expected_course = {'version': 1}
+        input_course = {'_rid': '_rid_test', 'version': 1}
+
+        output_course = CourseFetcher.tidy_course(input_course)
+        self.assertEqual(expected_course, output_course)
+
+    def test_self_is_deleted(self):
+        expected_course = {'version': 1}
+        input_course = {'_self': '_self_test', 'version': 1}
+
+        output_course = CourseFetcher.tidy_course(input_course)
+        self.assertEqual(expected_course, output_course)
+
+    def test_etag_is_deleted(self):
+        expected_course = {'version': 1}
+        input_course = {'_etag': '_etag_test', 'version': 1}
+
+        output_course = CourseFetcher.tidy_course(input_course)
+        self.assertEqual(expected_course, output_course)
+
+    def test_attachments_is_deleted(self):
+        expected_course = {'version': 1}
+        input_course = {'_attachments': '_attachments_test', 'version': 1}
+
+        output_course = CourseFetcher.tidy_course(input_course)
+        self.assertEqual(expected_course, output_course)
+
+    def test_ts_is_deleted(self):
+        expected_course = {'version': 1}
+        input_course = {'_ts': '_ts_test', 'version': 1}
+
+        output_course = CourseFetcher.tidy_course(input_course)
+        self.assertEqual(expected_course, output_course)
+
+    def test_institution_id_is_deleted(self):
+        expected_course = {'version': 1}
+        input_course = {'institution_id': '121', 'version': 1}
+
+        output_course = CourseFetcher.tidy_course(input_course)
+        self.assertEqual(expected_course, output_course)
+
+    def test_course_id_is_deleted(self):
+        expected_course = {'version': 1}
+        input_course = {'course_id': '231g31rkj', 'version': 1}
+
+        output_course = CourseFetcher.tidy_course(input_course)
+        self.assertEqual(expected_course, output_course)
+
+    def test_course_mode_is_deleted(self):
+        expected_course = {'version': 1}
+        input_course = {'course_mode': '1', 'version': 1}
+
+        output_course = CourseFetcher.tidy_course(input_course)
+        self.assertEqual(expected_course, output_course)
+
+    def test_with_all_keys_to_be_deleted(self):
+        expected_course = {'version': 1}
+        input_course = {'_rid': '_rid_test', '_self': '_self_test', '_etag': '_etag_test', '_attachments': '_attachments_test', '_ts': '_ts_test', 'institution_id': '111', 'course_id': '4r4t5', 'course_mode': '1', 'version': 1}
+
+        output_course = CourseFetcher.tidy_course(input_course)
+        self.assertEqual(expected_course, output_course)


### PR DESCRIPTION
### What

Use the new fields at root level of course document when querying database.

### How to review

Check all unit test pass and you can still retrieve resources from database.

You will need to be on`feature/course-compound-index-fields` branch on the beta-data-pipeline repository and re-build your courses collection.
