### PR TITLE
Set up CI with Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,10 +1,8 @@
-# DevOps Pipeline definition for the OFS Beta Backend Data Pipeline 
+# DevOps Pipeline definition for the OFS Beta Backend DataSet Pipeline 
 
 # The code branch that will trigger a build
 trigger:
-- feature/*
-- bugfix/*
-- refactor/*
+- release/*
 
 # The pr from branches to be included or excluded to trigger build
 pr: none


### PR DESCRIPTION
For the dataset-api repo the wizard does not prompt to select an existing yaml file with the repo. It just loads azure-pipelines.yml. This is a know issue - see this thread: https://developercommunity.visualstudio.com/content/problem/345452/new-yaml-pipeline-creator-does-not-allow-existing.html. Note sure why it doesn't prompt for this particular repo. Maybe the swagger.yml confuses it. Need to investigate.